### PR TITLE
reformat README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-Power Supply Controller
+# Power Supply Controller
 
 This is a custom designed hardware platform for the next gen power supply controller.
 
 Uses the DESY FWK FPGA Firmware Framework https://fpgafw.pages.desy.de/docs-pub/fwk/index.html
 
-Clone with --recurse-submodules to get the FWK repos
+## Requires
+
+* Xilinx 2022.2
+* git
+* python3
+
+## Building
+
+```sh
+. /path/to/Vitis/2022.2/settings64.sh
 
 git clone --recurse-submodules https://github.com/jamead/psc
+make env
 
-Setup Environment: make env (first time only)
+make cfg=hw project
+make cfg=hw build
 
-To build firmware make cfg=hw project (Sets up project)
-
-make cfg=hw gui (Open in Vivado)
-
-make cfg=hw build (Builds bit file)
-
-To build Software
-
-make cfg=sw project (Sets up project)
-
-make cfg=sw gui (Opens in Vitis)
-
-make cfg=sw build (Builds executable)
-
+make cfg=sw project
+make cfg=sw build
+```


### PR DESCRIPTION
Reformat the README to verbatim copy+paste.  Document vivado/vitis 2022.2 requirement.

These instructions work for me, but I am not clear how to cause the final bit file to be created.  It looks to me like the `make cfg=sw build` ends after linking `psc.elf`.  Presumably there is some other make target which ~~runs `updatemem` to insert this ELF into a BIT file?~~ creates a `.bin` file with both the ELF and BIT file?