### PR TITLE
PSC static alloc

### DIFF
--- a/src/sw/src/console.c
+++ b/src/sw/src/console.c
@@ -119,7 +119,7 @@ void set_resolution(void)
   u8 val;
 
   xil_printf("\r\nSet Resolution of PSC: 0=MS (18bit), 1=HS (20bit)");
-  if ((val = get_binary_input()) != -1) {
+  if ((val = get_binary_input()) != (u8)-1) {
      i2c_eeprom_writeBytes(48, &val, 1);
      xil_printf("Reboot for settings to take effect\r\n");
   }
@@ -252,8 +252,8 @@ void exec_menu(const char *head, const menu_entry_t *m, size_t m_len)
     choice = XUartPs_ReadReg(XPAR_XUARTPS_0_BASEADDR, XUARTPS_FIFO_OFFSET) & 0xFF;
 
 
-    if (isalpha(choice))
-      choice = toupper(choice);
+    if (isalpha((int)choice))
+      choice = toupper((int)choice);
     printf("%c\r\n\r\n", choice);
 
     for (i = 0; i < m_len; i++) {

--- a/src/sw/src/control.c
+++ b/src/sw/src/control.c
@@ -95,7 +95,7 @@ void write_ramptable(u32 chan, void *msg, u32 msglen)
   ramp_len = msglen / 4;
   xil_printf("Writing %d point Ramptable for Channel %d...\r\n",ramp_len, chan);
 
-	for (i=0;i<20;i++) {
+	for (i=0;i<20&&i<ramp_len;i++) {
 		data.u = htonl(msgptr[i]);
 		printf("%d: %f\r\n",i,data.f);
 	}

--- a/src/sw/src/control.h
+++ b/src/sw/src/control.h
@@ -1,4 +1,7 @@
+#ifndef CONTROL_H_INC
+#define CONTROL_H_INC
 
+#include <xil_types.h>
 
 
 //DAC modes
@@ -90,4 +93,4 @@
 void glob_settings(void *);
 void chan_settings(u32, void *, u32);
 
-
+#endif

--- a/src/sw/src/i2c.c
+++ b/src/sw/src/i2c.c
@@ -87,7 +87,7 @@ s32 i2c0_read(u8 *buf, u8 len, u8 addr) {
 
 	s32 status;
 
-	while (XIicPs_BusIsBusy(&IicPsInstance0));
+    while (XIicPs_BusIsBusy(&IicPsInstance0)) {};
     status = XIicPs_MasterRecvPolled(&IicPsInstance0, buf, len, addr);
     return status;
 }
@@ -106,7 +106,7 @@ s32 i2c1_read(u8 *buf, u8 len, u8 addr) {
 
 	s32 status;
 
-	while (XIicPs_BusIsBusy(&IicPsInstance1));
+    while (XIicPs_BusIsBusy(&IicPsInstance1)) {};
     status = XIicPs_MasterRecvPolled(&IicPsInstance1, buf, len, addr);
     return status;
 }

--- a/src/sw/src/listener.c
+++ b/src/sw/src/listener.c
@@ -16,11 +16,7 @@
 #include "local.h"
 
 
-
-// Static buffers + usage bitmap
-static char static_rxbufs[PSC_MAX_CLIENTS][PSC_MAX_RX_MSG_LEN];
-static uint8_t static_rxbufs_in_use[PSC_MAX_CLIENTS] = {0};
-
+//static char static_rxbufs[PSC_MAX_CLIENTS][PSC_MAX_RX_MSG_LEN];
 
 struct psc_client {
     struct psc_client *prev;
@@ -33,7 +29,6 @@ struct psc_client {
     psc_key *PSC;
 
     char *rxbuf;
-    int buf_index;
 };
 
 struct psc_key {
@@ -92,12 +87,9 @@ void psc_run(psc_key **key, const psc_config *config)
         (*config->start)(config->pvt, PSC);
 
     printf("Server ready on port %d\n", config->port);
-
-
-
     while(1) {
         psc_client *C = NULL;
-        //char *Cbuf = NULL;
+        char *Cbuf = NULL;
         struct sockaddr_in caddr;
         socklen_t clen = sizeof(caddr);
 
@@ -143,50 +135,26 @@ void psc_run(psc_key **key, const psc_config *config)
             sys_msleep(1000);
 
         } else if(PSC->client_count>=PSC_MAX_CLIENTS ||
-                  !(C = calloc(1,sizeof(*C)))) //   ||
-                  //!(Cbuf = malloc(PSC_MAX_RX_MSG_LEN)))
+                  !(C = calloc(1,sizeof(*C)))   ||
+                  !(Cbuf = malloc(PSC_MAX_RX_MSG_LEN)))
         {
         	printf("Client Count = %d\n",PSC->client_count);
-        	//printf("C = %d\n",(int)C);
-        	//printf("Cbuf = %d\n",(int)Cbuf);
+        	printf("C = %d\n",(int)C);
+        	printf("Cbuf = %d\n",(int)Cbuf);
             printf("Dropping client %s:%d (%d connected)\n",
                    inet_ntoa(caddr.sin_addr.s_addr),
                    ntohs(caddr.sin_port),
                    PSC->client_count);
             close(client);
             free(C);
-            //free(Cbuf);
+            free(Cbuf);
         } else {
-            // 🔎 Find the first available static buffer slot
-             int buf_index = -1;
-             for (int i = 0; i < PSC_MAX_CLIENTS; i++) {
-                 if (!static_rxbufs_in_use[i]) {
-                     buf_index = i;
-                     static_rxbufs_in_use[i] = 1;
-                     break;
-                 }
-             }
-
-             if (buf_index == -1) {
-                 // Shouldn't happen because of client count check
-                 printf("No static RX buffer available! Dropping client.\n");
-                 close(client);
-                 free(C);
-                 continue;
-             }
-
-             printf("PSC Client Count: %d (using buffer index %d)\n", PSC->client_count, buf_index);
-
-
-
         	printf("PSC Client Count: %d\n",PSC->client_count);
             C->PSC = PSC;
-        	C->rxbuf = static_rxbufs[buf_index];
-            //C->rxbuf = Cbuf;
+        	//C->rxbuf = static_rxbufs[PSC->client_count];
+            C->rxbuf = Cbuf;
             C->sock = client;
             C->peeraddr = caddr;
-            C->buf_index = buf_index; // Save index for freeing later
-
 
             // LwIP does not allow thread creation to fail
             sys_thread_new("handle client", handle_client, C, THREAD_STACKSIZE, DEFAULT_THREAD_PRIO); //config->client_prio);
@@ -230,7 +198,7 @@ static void handle_client(void *raw)
         (*C->PSC->conf->recv)(C->PSC->conf->pvt, C, msgid, msglen, C->rxbuf);
     }
 
-    /* patch ourselves out of the client list */
+    /* patch outselves out of the client list */
     sys_mutex_lock(&C->PSC->sendguard);
     if(C->next)
         C->next->prev = C->prev;
@@ -239,13 +207,6 @@ static void handle_client(void *raw)
     else
         C->PSC->client_head = C->next;
     C->PSC->client_count--;
-
-    // Release the static buffer
-      if (C->buf_index >= 0 && C->buf_index < PSC_MAX_CLIENTS) {
-          printf("Releasing static buffer index %d\n", C->buf_index);
-          static_rxbufs_in_use[C->buf_index] = 0;
-      }
-
     sys_mutex_unlock(&C->PSC->sendguard);
 
     if(C->PSC->conf->conn)
@@ -260,7 +221,7 @@ static void handle_client(void *raw)
     close(C->sock);
     sys_mutex_unlock(&C->PSC->sendguard);
 
-    //free(C->rxbuf);
+    free(C->rxbuf);
     free(C);
     vTaskDelete(NULL);
 }

--- a/src/sw/src/listener.c
+++ b/src/sw/src/listener.c
@@ -15,20 +15,19 @@
 #include "pscmsg.h"
 #include "local.h"
 
-
-//static char static_rxbufs[PSC_MAX_CLIENTS][PSC_MAX_RX_MSG_LEN];
+#if PSC_MAX_CLIENTS > 32
+#  error PSC_MAX_CLIENTS too large
+#endif
 
 struct psc_client {
-    struct psc_client *prev;
-    struct psc_client *next;
-    int active;
+    unsigned index; // ... in psc_key::clients
 
-    int sock;
+    int sock; // set to -1 on send error
     struct sockaddr_in peeraddr;
 
     psc_key *PSC;
 
-    char *rxbuf;
+    char rxbuf[8+PSC_MAX_RX_MSG_LEN];
 };
 
 struct psc_key {
@@ -37,8 +36,8 @@ struct psc_key {
 
     int listen_sock;
 
-    unsigned client_count;
-    psc_client *client_head;
+    uint32_t clients_used;
+    struct psc_client clients[PSC_MAX_CLIENTS];
 };
 
 static void handle_client(void *raw);
@@ -53,6 +52,43 @@ static void handle_client(void *raw);
     printf("Error: %s:%d %s (errno=%d): " fmt "\n", __FILE__, __LINE__, __FUNCTION__, errno, ##__VA_ARGS__); return; \
     }}while(0)
 
+static
+struct psc_client* psc_client_alloc(struct psc_key *key)
+{
+    psc_client* ret = NULL;
+    sys_mutex_lock(&key->sendguard);
+
+    for(unsigned i=0; i<PSC_MAX_CLIENTS; i++) {
+        if(key->clients_used & (1u<<i))
+            continue;
+
+        key->clients_used |= (1u<<i);
+
+        ret = &key->clients[i];
+        memset(ret, 0, sizeof(*ret));
+        ret->index = i;
+        ret->PSC = key;
+        break;
+    }
+
+    sys_mutex_unlock(&key->sendguard);
+    return ret;
+}
+
+static
+void psc_client_free(struct psc_client* cli)
+{
+    struct psc_key *key = cli->PSC;
+    sys_mutex_lock(&key->sendguard);
+
+    key->clients_used &= ~(1u<<cli->index);
+    // spoil
+    memset(cli, 0, sizeof(*cli));
+    cli->PSC = NULL;
+
+    sys_mutex_unlock(&key->sendguard);
+}
+
 void psc_run(psc_key **key, const psc_config *config)
 {
     struct sockaddr_in laddr;
@@ -66,8 +102,8 @@ void psc_run(psc_key **key, const psc_config *config)
 
     ERROR(key && *key, "key already set");
 
-    PSC = calloc(1, sizeof(*PSC));
-    ERROR(!PSC, "Allocation");
+    PSC = mem_calloc(1, sizeof(*PSC));
+    ERROR(!PSC, "Unable to allocate %zu bytes for PSC", sizeof(*PSC));
     PSC->conf = config;
 
     PERROR(sys_mutex_new(&PSC->sendguard)!=ERR_OK, "sendguard");
@@ -89,7 +125,6 @@ void psc_run(psc_key **key, const psc_config *config)
     printf("Server ready on port %d\n", config->port);
     while(1) {
         psc_client *C = NULL;
-        char *Cbuf = NULL;
         struct sockaddr_in caddr;
         socklen_t clen = sizeof(caddr);
 
@@ -134,42 +169,24 @@ void psc_run(psc_key **key, const psc_config *config)
             printf("accept error %d for port %d\n", errno, config->port);
             sys_msleep(1000);
 
-        } else if(PSC->client_count>=PSC_MAX_CLIENTS ||
-                  !(C = calloc(1,sizeof(*C)))   ||
-                  !(Cbuf = malloc(PSC_MAX_RX_MSG_LEN)))
-        {
-        	printf("Client Count = %d\n",PSC->client_count);
-        	printf("C = %d\n",(int)C);
-        	printf("Cbuf = %d\n",(int)Cbuf);
-            printf("Dropping client %s:%d (%d connected)\n",
+        } else if(!(C = psc_client_alloc(PSC))) {
+            printf("Dropping client %s:%d (0x%x connected)\n",
                    inet_ntoa(caddr.sin_addr.s_addr),
                    ntohs(caddr.sin_port),
-                   PSC->client_count);
+                   (unsigned)PSC->clients_used);
             close(client);
-            free(C);
-            free(Cbuf);
+
         } else {
-        	printf("PSC Client Count: %d\n",PSC->client_count);
-            C->PSC = PSC;
-        	//C->rxbuf = static_rxbufs[PSC->client_count];
-            C->rxbuf = Cbuf;
             C->sock = client;
             C->peeraddr = caddr;
 
             // LwIP does not allow thread creation to fail
             sys_thread_new("handle client", handle_client, C, THREAD_STACKSIZE, DEFAULT_THREAD_PRIO); //config->client_prio);
 
-            sys_mutex_lock(&PSC->sendguard);
-            C->next = PSC->client_head;
-            PSC->client_head = C;
-            PSC->client_count++;
-            C->active = 1;
-            sys_mutex_unlock(&PSC->sendguard);
-
-            printf("New client %s:%d (%d connected)\n",
+            printf("New client %s:%d (0x%x connected)\n",
                    inet_ntoa(caddr.sin_addr.s_addr),
                    ntohs(caddr.sin_port),
-                   PSC->client_count);
+                   (unsigned)PSC->clients_used);
         }
     }
 
@@ -180,69 +197,59 @@ void psc_run(psc_key **key, const psc_config *config)
 static void handle_client(void *raw)
 {
     psc_client *C = raw;
+    struct psc_key* PSC = C->PSC;
+    int sock = C->sock;
 
     printf("In handle_client...\n");
 
-    if(C->PSC->conf->conn)
-        (*C->PSC->conf->conn)(C->PSC->conf->pvt, PSC_CONN, C);
+    if(PSC->conf->conn)
+        (*PSC->conf->conn)(PSC->conf->pvt, PSC_CONN, C);
 
     while(1) {
-
         uint16_t msgid;
-        uint32_t msglen = PSC_MAX_RX_MSG_LEN;
-        if(psc_recvmsg(C->sock, &msgid, C->rxbuf, &msglen, 0))
+        uint32_t msglen = sizeof(C->rxbuf);
+        if(psc_recvmsg(sock, &msgid, C->rxbuf, &msglen, 0))
             break; /* read error */
 
-
         //function call to the recv function (which is client message)
-        (*C->PSC->conf->recv)(C->PSC->conf->pvt, C, msgid, msglen, C->rxbuf);
+        (*PSC->conf->recv)(PSC->conf->pvt, C, msgid, msglen, C->rxbuf);
     }
 
-    /* patch outselves out of the client list */
-    sys_mutex_lock(&C->PSC->sendguard);
-    if(C->next)
-        C->next->prev = C->prev;
-    if(C->prev)
-        C->prev->next = C->next;
-    else
-        C->PSC->client_head = C->next;
-    C->PSC->client_count--;
-    sys_mutex_unlock(&C->PSC->sendguard);
+    if(PSC->conf->conn)
+        (*PSC->conf->conn)(PSC->conf->pvt, PSC_DIS, C);
 
-    if(C->PSC->conf->conn)
-        (*C->PSC->conf->conn)(C->PSC->conf->pvt, PSC_DIS, C);
-
-    printf("client disconnect %s:%d (%d connected)\n",
+    printf("client disconnect %s:%d (0x%x connected)\n",
            inet_ntoa(C->peeraddr.sin_addr.s_addr),
            ntohs(C->peeraddr.sin_port),
-           C->PSC->client_count);
+           (unsigned)PSC->clients_used);
 
-    sys_mutex_lock(&C->PSC->sendguard);
-    close(C->sock);
-    sys_mutex_unlock(&C->PSC->sendguard);
+    psc_client_free(C);
+    sys_mutex_lock(&PSC->sendguard);
+    close(sock);
+    sys_mutex_unlock(&PSC->sendguard);
 
-    free(C->rxbuf);
-    free(C);
     vTaskDelete(NULL);
 }
 
 
 void psc_send(psc_key *PSC, uint16_t msgid, uint32_t msglen, const void *msg)
 {
-    psc_client *C;
     if(!PSC)
         return;
     sys_mutex_lock(&PSC->sendguard);
-    for(C=PSC->client_head; C; C=C->next) {
+    for(unsigned idx=0; idx<PSC_MAX_CLIENTS; idx++) {
         int ret;
-        if(!C->active)
+        psc_client *C = &PSC->clients[idx];
+
+        if(!(PSC->clients_used & (1u<<idx)) || C->sock == -1)
             continue;
+
         ret = psc_sendmsg(C->sock, msgid, msg, msglen, 0);
         if(ret) {
             printf("%s senderror errno=%d\n", __FUNCTION__, errno);
             /* client error */
-            C->active = 0;
             close(C->sock); /* will wake up RX thread */
+            C->sock = -1;
         }
     }
     sys_mutex_unlock(&PSC->sendguard);
@@ -251,12 +258,14 @@ void psc_send(psc_key *PSC, uint16_t msgid, uint32_t msglen, const void *msg)
 void psc_send_one(psc_client *C, uint16_t msgid, uint32_t msglen, const void *msg)
 {
     sys_mutex_lock(&C->PSC->sendguard);
-    int ret = psc_sendmsg(C->sock, msgid, msg, msglen, 0);
-    if(ret) {
-        printf("%s senderror errno=%d\n", __FUNCTION__, errno);
-        /* client error */
-        C->active = 0;
-        close(C->sock); /* will wake up RX thread */
+    if(C->sock != -1) {
+        int ret = psc_sendmsg(C->sock, msgid, msg, msglen, 0);
+        if(ret) {
+            printf("%s senderror errno=%d\n", __FUNCTION__, errno);
+            /* client error */
+            close(C->sock); /* will wake up RX thread */
+            C->sock = -1;
+        }
     }
     sys_mutex_unlock(&C->PSC->sendguard);
 }

--- a/src/sw/src/lstats.c
+++ b/src/sw/src/lstats.c
@@ -54,6 +54,12 @@ void lstats_push(void *unused)
                 uint32_t vccint; //60
                 uint32_t vccaux; //64
             } sensors;
+            struct {
+                uint32_t avail; // 68
+                uint32_t avail_largest_block; // 72
+                uint32_t avail_lowest; // 76
+                uint32_t nactive; // 80
+            } os_mem;
             // for backwards compatibility, must only append new values.
         } msg = {};
 
@@ -83,6 +89,15 @@ void lstats_push(void *unused)
 #endif
 #undef MV
 #endif // LWIP_STATS
+
+        {
+            HeapStats_t stats;
+            vPortGetHeapStats(&stats);
+            msg.os_mem.avail = htonl(stats.xAvailableHeapSpaceInBytes);
+            msg.os_mem.avail_lowest = htonl(stats.xMinimumEverFreeBytesRemaining);
+            msg.os_mem.avail_largest_block = htonl(stats.xSizeOfLargestFreeBlockInBytes);
+            msg.os_mem.nactive = htonl(stats.xNumberOfSuccessfulAllocations - stats.xNumberOfSuccessfulFrees);
+        }
 
         //char buffer[512];
         //vTaskList(buffer);

--- a/src/sw/src/main.c
+++ b/src/sw/src/main.c
@@ -72,10 +72,11 @@ void client_msg(void *pvt, psc_client *ckey, uint16_t msgid, uint32_t msglen, vo
             break;
         case 101:
         	write_ramptable(1,msg,msglen);
+            break;
         case 102:
         case 103:
         case 104:
-
+            break;
     }
 
 

--- a/src/sw/src/main.c
+++ b/src/sw/src/main.c
@@ -52,7 +52,7 @@ void client_msg(void *pvt, psc_client *ckey, uint16_t msgid, uint32_t msglen, vo
 {
     (void)pvt;
 
-	//xil_printf("In Client_Msg:  MsgID=%d   MsgLen=%d\r\n",msgid,msglen);
+	xil_printf("In Client_Msg:  MsgID=%d   MsgLen=%d\r\n",msgid,msglen);
 
 
     //blink front panel LED

--- a/src/sw/src/sadata.c
+++ b/src/sw/src/sadata.c
@@ -2,6 +2,7 @@
 // Gather and Send 10Hz data
 
 #include <stdio.h>
+#include <math.h>
 
 #include <xsysmon.h>
 #include <xparameters.h>
@@ -53,6 +54,8 @@ float ReadAccumSA(u32 reg_addr, u32 ave_mode) {
  	   averaged = raw / 167.0;
     else if (ave_mode == 2)
  	   averaged = raw / 500.0;
+    else
+       averaged = NAN;
 
    // printf("Raw: %d    Ave%f  \r\n",(int)raw, averaged);
     return averaged;

--- a/src/sw/tcl/main.tcl
+++ b/src/sw/tcl/main.tcl
@@ -77,6 +77,7 @@ proc doOnCreate {} {
   bsp config dhcp_does_arp_check true
   bsp config lwip_dhcp "true"
   bsp config pbuf_pool_size 2048 
+  bsp config mem_size 16777216
   bsp config tick_rate 750
   bsp config lwip_stats true 
   # bsp config lwip_debug true


### PR DESCRIPTION
Status: Tested in simulator

Switch PSC server to use (mostly) static allocations.  `psc_run()` will make one allocation for each server instance (`psc_key`).  For the current limits of 4 clients and 50000 byte RX buffer, this works out to ~256KB per server.  This does not include whatever additional allocations LWIP makes for each socket.

These allocations are made from the LWIP heap (`mem_calloc()`), instead of the freertos heap (`calloc()`).  So the LWIP heap size `bsp config mem_size ...` is relevant.